### PR TITLE
warnings will become error if they increase

### DIFF
--- a/models/core/blocks.yml
+++ b/models/core/blocks.yml
@@ -12,6 +12,9 @@ models:
       - sequence_gaps:
           column_name: block_id
           where: BLOCK_TIMESTAMP < CURRENT_DATE - 1
+          config:
+            error_if: ">10"
+            warn_if:  ">0"
 
     columns:
       - name: block_id

--- a/models/core/blocks.yml
+++ b/models/core/blocks.yml
@@ -13,8 +13,8 @@ models:
           column_name: block_id
           where: BLOCK_TIMESTAMP < CURRENT_DATE - 1
           config:
+            severity: warn
             error_if: ">10"
-            warn_if:  ">0"
 
     columns:
       - name: block_id

--- a/models/core/txs.yml
+++ b/models/core/txs.yml
@@ -10,8 +10,6 @@ models:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - TX_HASH
-      - tx_gaps:
-          where: BLOCK_TIMESTAMP < CURRENT_DATE      
     columns:
       - name: block_timestamp
         description: The time when the block was mined.

--- a/models/staging/stg_txs.yml
+++ b/models/staging/stg_txs.yml
@@ -24,6 +24,9 @@ models:
               column_block: BLOCK_ID
               column_tx_count: tx_count
               where: BLOCK_TIMESTAMP < CURRENT_DATE
+              config:
+                severity: warn
+                error_if: ">78"
 
       - name: tx_block_index
         description: The index of the transaction within the block. Starts at 0.


### PR DESCRIPTION
Harmony has been throwing 2 errors every day since we built the repo. The two errors pertain to the block_gaps and transaction_gaps. I am turning these tests into warnings because of the following reasons: 

1- Total block gaps has always (since our fork) been 31 and never exceeded that amount. Currently they don’t have a material effect to our sushi__ez_swaps table, which is the only table out of this repo that we’re exposing. Filling these gaps will be a nice to have. 

2- Total transaction gaps have always (since our fork) stuck to 4601 and never exceeded that amount. Currently they don’t have a material effect on our sushi__ez_swaps table, which is the only table out of this repo that we’re exposing. Filling these gaps will be a nice to have. 

P.S. I am still keeping the gap filling ticket open for the platform and hope that one day they fill them. 